### PR TITLE
Restrict fmt and Boost dependency to the tests and examples

### DIFF
--- a/cmake/pika_algorithms_setup_boost.cmake
+++ b/cmake/pika_algorithms_setup_boost.cmake
@@ -5,7 +5,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if(NOT TARGET Boost::boost)
+if(NOT TARGET Boost::boost AND (PIKA_ALGORITHMS_WITH_TESTS
+                                OR PIKA_ALGORITHMS_WITH_EXAMPLES)
+)
   # Add additional version to recognize
   # cmake-format: off
   set(Boost_ADDITIONAL_VERSIONS

--- a/cmake/pika_algorithms_setup_fmt.cmake
+++ b/cmake/pika_algorithms_setup_fmt.cmake
@@ -4,4 +4,6 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-pika_algorithms_find_package(fmt 9.0.0 REQUIRED)
+if(PIKA_ALGORITHMS_WITH_TESTS OR PIKA_ALGORITHMS_WITH_EXAMPLES)
+  pika_algorithms_find_package(fmt 9.0.0 REQUIRED)
+endif()

--- a/cmake/pika_algorithms_setup_target.cmake
+++ b/cmake/pika_algorithms_setup_target.cmake
@@ -132,7 +132,9 @@ function(pika_algorithms_setup_target target)
         target_precompile_headers(
           ${target} REUSE_FROM pika_algorithms_exe_precompiled_headers
         )
-        target_link_libraries(${target} PRIVATE Boost::boost fmt::fmt)
+        if(PIKA_ALGORITHMS_WITH_TESTS OR PIKA_ALGORITHMS_WITH_EXAMPLES)
+          target_link_libraries(${target} PRIVATE Boost::boost fmt::fmt)
+        endif()
       endif()
     endif()
   endif()


### PR DESCRIPTION
Fix #9 