### PR TITLE
Fix `pika_algorithms_find_package`

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -55,8 +55,8 @@ status = [
   "jenkins/cscs-daint/gcc-11-release",
   "jenkins/cscs-daint/gcc-12-debug",
   "jenkins/cscs-daint/gcc-12-release",
-  # "jenkins/cscs-daint/gcc-cuda-debug",
-  # "jenkins/cscs-daint/gcc-cuda-release",
+  "jenkins/cscs-daint/gcc-cuda-debug",
+  "jenkins/cscs-daint/gcc-cuda-release",
 ]
 required_approvals = 0
 delete_merged_branches = true

--- a/cmake/pika_algorithms_find_package.cmake
+++ b/cmake/pika_algorithms_find_package.cmake
@@ -6,10 +6,10 @@
 
 include(CMakeFindDependencyMacro)
 
-function(pika_algorithms_find_package)
+macro(pika_algorithms_find_package)
   if(PIKA_ALGORITHMS_FIND_PACKAGE)
     find_dependency(${ARGN})
   else()
     find_package(${ARGN})
   endif()
-endfunction(pika_algorithms_find_package)
+endmacro(pika_algorithms_find_package)


### PR DESCRIPTION
Make it a macro so that `find_package/dependency` are scoped correctly.

Apparently CMake cares whether `find_package/dependency` is called within a function or a macro. The failure case when it's a function is that CUDA will be found by the pika configuration file, but when linking to `pika::pika` CMake will complain with:
```
-- Configuring done
CMake Error in testing/testing/CMakeLists.txt:
  No known features for CUDA compiler

  ""

  version .
```
A manual `enable_language(CUDA)` in the top-level scope will "fix" this as well, but since it's pika's responsibility to find CUDA, `pika_algorithms_find_package` should just be a macro so that `enable_language(CUDA)` is called in the correct scope to start with.

May fix part of #3. Fixes the configuration error here: https://cdash.cscs.ch/build/57573/configure. CI will tell if the build itself is also good.