### PR TITLE
Replace `pika::spinlock` with `pika::mutex`

### DIFF
--- a/.jenkins/cscs/env-clang-13.sh
+++ b/.jenkins/cscs/env-clang-13.sh
@@ -11,8 +11,9 @@ hwloc_version="2.6.0"
 pika_version="0.11.0"
 spack_compiler="clang@${clang_version}"
 spack_arch="cray-cnl7-broadwell"
+stdexec_version="6510f5bd69cc03b24668f26eda3dd3cca7e81bb2"
 
-spack_spec="pika-algorithms@main arch=${spack_arch} %${spack_compiler} cxxflags=-stdlib=libc++ cxxstd=${cxx_std} ^pika@${pika_version} cxxflags=-stdlib=libc++ malloc=system +p2300 ^boost@${boost_version} ^hwloc@${hwloc_version}"
+spack_spec="pika-algorithms@main arch=${spack_arch} %${spack_compiler} cxxflags=-stdlib=libc++ cxxstd=${cxx_std} ^pika@${pika_version} cxxflags=-stdlib=libc++ malloc=system +stdexec ^boost@${boost_version} ^hwloc@${hwloc_version} ^stdexec@${stdexec_version}"
 
 configure_extra_options+=" -DCMAKE_CXX_FLAGS=-stdlib=libc++"
 configure_extra_options+=" -DPIKA_ALGORITHMS_WITH_CXX_STANDARD=${cxx_std}"

--- a/.jenkins/cscs/env-clang-14.sh
+++ b/.jenkins/cscs/env-clang-14.sh
@@ -9,10 +9,11 @@ clang_version="14.0.6"
 boost_version="1.79.0"
 hwloc_version="2.7.0"
 pika_version="0.11.0"
+stdexec_version="6510f5bd69cc03b24668f26eda3dd3cca7e81bb2"
 spack_compiler="clang@${clang_version}"
 spack_arch="cray-cnl7-haswell"
 
-spack_spec="pika-algorithms@main arch=${spack_arch} %${spack_compiler} cxxstd=${cxx_std} ^pika@${pika_version} malloc=system +p2300 ^boost@${boost_version} ^hwloc@${hwloc_version}"
+spack_spec="pika-algorithms@main arch=${spack_arch} %${spack_compiler} cxxstd=${cxx_std} ^pika@${pika_version} malloc=system +stdexec ^boost@${boost_version} ^hwloc@${hwloc_version} ^stdexec@${stdexec_version}"
 
 configure_extra_options+=" -DPIKA_ALGORITHMS_WITH_CXX_STANDARD=${cxx_std}"
 

--- a/include/pika/parallel/algorithms/partition.hpp
+++ b/include/pika/parallel/algorithms/partition.hpp
@@ -451,7 +451,7 @@ namespace pika {
 #include <pika/futures/future.hpp>
 #include <pika/iterator_support/traits/is_iterator.hpp>
 #include <pika/modules/async.hpp>
-#include <pika/synchronization/spinlock.hpp>
+#include <pika/synchronization/mutex.hpp>
 #include <pika/type_support/unused.hpp>
 
 #include <pika/algorithms/traits/projected.hpp>
@@ -874,7 +874,7 @@ namespace pika::parallel::detail {
             std::size_t left_, right_;
             std::size_t block_size_;
             std::int64_t left_block_no_{-1}, right_block_no_{1};
-            pika::spinlock mutex_;
+            pika::mutex mutex_;
         };
 
         // block manager for forward access iterator.
@@ -955,7 +955,7 @@ namespace pika::parallel::detail {
             std::vector<block<FwdIter>> blocks_;
             std::size_t left_, right_;
             std::int64_t left_block_no_{-1}, right_block_no_{1};
-            pika::spinlock mutex_;
+            pika::mutex mutex_;
         };
 
         // std::swap_ranges doesn't support overlapped ranges in standard.

--- a/tests/regressions/for_loop_2281.cpp
+++ b/tests/regressions/for_loop_2281.cpp
@@ -7,6 +7,7 @@
 #include <pika/algorithm.hpp>
 #include <pika/execution.hpp>
 #include <pika/init.hpp>
+#include <pika/mutex.hpp>
 #include <pika/testing.hpp>
 
 #include <cstddef>
@@ -18,11 +19,11 @@
 ///////////////////////////////////////////////////////////////////////////////
 int pika_main()
 {
-    pika::spinlock mtx;
+    pika::mutex mtx;
     std::set<pika::thread::id> thread_ids;
 
     pika::for_loop(pika::execution::par, 0, 100, [&](int) {
-        std::lock_guard<pika::spinlock> l(mtx);
+        std::lock_guard<pika::mutex> l(mtx);
         thread_ids.insert(pika::this_thread::get_id());
     });
 
@@ -31,7 +32,7 @@ int pika_main()
     thread_ids.clear();
 
     pika::for_loop_n(pika::execution::par, 0, 100, [&](int) {
-        std::lock_guard<pika::spinlock> l(mtx);
+        std::lock_guard<pika::mutex> l(mtx);
         thread_ids.insert(pika::this_thread::get_id());
     });
 


### PR DESCRIPTION
Fixes compilation with latest pika main.

To do:
- [x] CI changes