### PR TITLE
Don't use removed scheduler mode `fast_idle` in tests

### DIFF
--- a/tests/performance/foreach_report.cpp
+++ b/tests/performance/foreach_report.cpp
@@ -39,7 +39,6 @@ int pika_main(pika::program_options::variables_map& vm)
     test_count = vm["test_count"].as<int>();
     chunk_size = vm["chunk_size"].as<int>();
     disable_stealing = vm.count("disable_stealing");
-    fast_idle_mode = vm.count("fast_idle_mode");
 
     // verify that input is within domain of program
     if (test_count == 0 || test_count < 0)
@@ -57,11 +56,6 @@ int pika_main(pika::program_options::variables_map& vm)
     {
         pika::threads::remove_scheduler_mode(
             ::pika::threads::scheduler_mode::enable_stealing);
-    }
-    if (fast_idle_mode)
-    {
-        pika::threads::add_scheduler_mode(
-            ::pika::threads::scheduler_mode::fast_idle_mode);
     }
 
     {
@@ -128,7 +122,6 @@ int main(int argc, char* argv[])
         ("chunk_size", value<int>()->default_value(0),
             "number of iterations to combine while parallelization")
         ("disable_stealing", "disable thread stealing")
-        ("fast_idle_mode", "enable fast idle mode")
         ;
     // clang-format on
 

--- a/tests/performance/foreach_scaling.cpp
+++ b/tests/performance/foreach_scaling.cpp
@@ -235,7 +235,6 @@ int pika_main(pika::program_options::variables_map& vm)
     chunk_size = vm["chunk_size"].as<int>();
     num_overlapping_loops = vm["overlapping_loops"].as<int>();
     disable_stealing = vm.count("disable_stealing");
-    fast_idle_mode = vm.count("fast_idle_mode");
 
     bool enable_all = vm.count("enable_all");
     if (!vm.count("parallel_foreach") && !vm.count("task_foreach") &&
@@ -262,10 +261,6 @@ int pika_main(pika::program_options::variables_map& vm)
         {
             pika::threads::remove_scheduler_mode(
                 scheduler_mode::enable_stealing);
-        }
-        if (fast_idle_mode)
-        {
-            pika::threads::add_scheduler_mode(scheduler_mode::fast_idle_mode);
         }
 
         // results
@@ -390,11 +385,6 @@ int pika_main(pika::program_options::variables_map& vm)
         {
             pika::threads::add_scheduler_mode(scheduler_mode::enable_stealing);
         }
-        if (fast_idle_mode)
-        {
-            pika::threads::remove_scheduler_mode(
-                scheduler_mode::fast_idle_mode);
-        }
 
         if (csvoutput)
         {
@@ -507,7 +497,6 @@ int main(int argc, char* argv[])
             "use specified executor (possible values: forkjoin, "
             "scheduler, or parallel (default)")
         ("disable_stealing", "disable thread stealing")
-        ("fast_idle_mode", "enable fast idle mode")
 
         ("enable_all", "enable all benchmarks")
         ("parallel_foreach", "enable parallel_foreach")

--- a/tests/performance/foreach_scaling_helpers.hpp
+++ b/tests/performance/foreach_scaling_helpers.hpp
@@ -35,7 +35,6 @@ int test_count = 100;
 int chunk_size = 0;
 int num_overlapping_loops = 0;
 bool disable_stealing = false;
-bool fast_idle_mode = false;
 unsigned int seed = std::random_device{}();
 std::mt19937 gen(seed);
 


### PR DESCRIPTION
It will be removed in pika 0.16.0.